### PR TITLE
feat: client user

### DIFF
--- a/packages/guilded-api-typings/lib/v1/ws/Events.ts
+++ b/packages/guilded-api-typings/lib/v1/ws/Events.ts
@@ -31,6 +31,13 @@ export interface SkeletonWSPayload {
 export interface WSWelcomePayload extends SkeletonWSPayload {
     d: {
         heartbeatIntervalMs: number;
+        user: {
+            id: string;
+            botId: string;
+            name: string;
+            createdAt: string;
+            createdBy: string;
+        };
         lastMessageId: string;
     };
 }

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -49,7 +49,7 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
     bans = new GlobalMemberBanManager(this);
 
     /** The user belonging to this bot */
-    user: User | null = null;
+    user: ClientUser | null = null;
 
     constructor(public options: ClientOptions) {
         if (typeof options !== "object") throw new Error("Must provide options in client constructor in the form of an object.");

--- a/packages/guilded.js/lib/structures/User.ts
+++ b/packages/guilded.js/lib/structures/User.ts
@@ -1,5 +1,5 @@
 import { Base } from "./Base";
-import type { UserPayload } from "@guildedjs/guilded-api-typings";
+import type { UserPayload, WSWelcomePayload } from "@guildedjs/guilded-api-typings";
 import type Client from "./Client";
 
 export class User extends Base<UserPayload> {
@@ -15,6 +15,18 @@ export class User extends Base<UserPayload> {
         this.name = data.name;
         this.createdAt = new Date(data.createdAt);
         this.type = data.type === "bot" ? UserType.Bot : UserType.User;
+    }
+}
+
+export class ClientUser extends User {
+    // User who has created this bot
+    readonly createdBy: string;
+    // The bot ID (not to be confused with the user ID) of this bot
+    readonly botId: string;
+    constructor(client: Client, data: WSWelcomePayload["d"]["user"]) {
+        super(client, { ...data, type: "bot" });
+        this.createdBy = data.createdBy;
+        this.botId = data.botId;
     }
 }
 

--- a/packages/ws/lib/WebSocketManager.ts
+++ b/packages/ws/lib/WebSocketManager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 import { ROUTES } from "@guildedjs/common";
-import { SkeletonWSPayload, WSEvent, WSOpCodes } from "@guildedjs/guilded-api-typings";
+import { SkeletonWSPayload, WSEvent, WSOpCodes, WSWelcomePayload } from "@guildedjs/guilded-api-typings";
 import { EventEmitter } from "events";
 import type TypedEmitter from "typed-emitter";
 import WebSocket from "ws";
@@ -118,7 +118,7 @@ export default class WebSocketManager {
                 break;
             // Auto handled by ws lib
             case WSOpCodes.WELCOME:
-                this.emitter.emit("ready");
+                this.emitter.emit("ready", (EVENT_DATA as WSWelcomePayload).d.user);
                 break;
             default:
                 this.emitter.emit("unknown", "unknown opcode", packet);
@@ -160,5 +160,5 @@ type WebsocketManagerEvents = {
     unknown: (reason: string, data: any) => unknown;
     reconnect: () => unknown;
     gatewayEvent: (event: keyof WSEvent, data: SkeletonWSPayload) => unknown;
-    ready: () => unknown;
+    ready: (user: WSWelcomePayload["d"]["user"]) => unknown;
 };


### PR DESCRIPTION
This PR integrates the changes in the Guilded API that provides client user data on welcome ws event.

Status

-   [X] Code changes have been tested.

Semantic versioning classification:

-   [X] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
