### PR TITLE
fix(framework): file name and prefix & export bug fixes

### DIFF
--- a/packages/framework/lib/BotClient.ts
+++ b/packages/framework/lib/BotClient.ts
@@ -1,3 +1,5 @@
+import { parse } from "path";
+
 import Collection from "@discordjs/collection";
 import { Client, Message } from "guilded.js";
 import path from "path";
@@ -41,7 +43,7 @@ export class BotClient extends Client {
 
     async loadFile(result: any, dir: string, collection: Collection<string, any>): Promise<void> {
         const [filename, file] = result;
-        const name = filename.substring(0, filename.length - 3);
+        const name = parse(filename).name;
         const piece = file.default ? new file.default(this, name) : new file(this, name);
 
         let cmd: Command | undefined = undefined;

--- a/packages/framework/lib/BotClient.ts
+++ b/packages/framework/lib/BotClient.ts
@@ -1,5 +1,3 @@
-import { parse } from "path";
-
 import Collection from "@discordjs/collection";
 import { Client, Message } from "guilded.js";
 import path from "path";
@@ -43,7 +41,7 @@ export class BotClient extends Client {
 
     async loadFile(result: any, dir: string, collection: Collection<string, any>): Promise<void> {
         const [filename, file] = result;
-        const name = parse(filename).name;
+        const { name } = path.parse(filename);
         const piece = file.default ? new file.default(this, name) : new file(this, name);
 
         let cmd: Command | undefined = undefined;
@@ -281,3 +279,5 @@ export interface MessageCollector extends CollectMessagesOptions {
     /** Where the messages are stored if the amount to collect is more than 1. */
     messages: Message[];
 }
+
+export default BotClient;

--- a/packages/framework/lib/BotClient.ts
+++ b/packages/framework/lib/BotClient.ts
@@ -41,7 +41,7 @@ export class BotClient extends Client {
 
     async loadFile(result: any, dir: string, collection: Collection<string, any>): Promise<void> {
         const [filename, file] = result;
-        const name = filename.substring(0, filename.length - 2);
+        const name = filename.substring(0, filename.length - 3);
         const piece = file.default ? new file.default(this, name) : new file(this, name);
 
         let cmd: Command | undefined = undefined;

--- a/packages/framework/lib/arguments/...string.ts
+++ b/packages/framework/lib/arguments/...string.ts
@@ -14,3 +14,5 @@ export class RemainingStringArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default RemainingStringArgument

--- a/packages/framework/lib/arguments/boolean.ts
+++ b/packages/framework/lib/arguments/boolean.ts
@@ -16,3 +16,5 @@ export class BooleanArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default BooleanArgument;

--- a/packages/framework/lib/arguments/command.ts
+++ b/packages/framework/lib/arguments/command.ts
@@ -20,3 +20,5 @@ export class CommandTypeArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default CommandTypeArgument;

--- a/packages/framework/lib/arguments/duration.ts
+++ b/packages/framework/lib/arguments/duration.ts
@@ -15,3 +15,5 @@ export class DurationArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default DurationArgument;

--- a/packages/framework/lib/arguments/number.ts
+++ b/packages/framework/lib/arguments/number.ts
@@ -21,3 +21,5 @@ export class NumberArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default NumberArgument;

--- a/packages/framework/lib/arguments/string.ts
+++ b/packages/framework/lib/arguments/string.ts
@@ -20,3 +20,5 @@ export class StringArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default StringArgument;

--- a/packages/framework/lib/arguments/subcommand.ts
+++ b/packages/framework/lib/arguments/subcommand.ts
@@ -20,3 +20,5 @@ export class SubcommandArgument extends Argument {
         // shut up eslint
     }
 }
+
+export default SubcommandArgument;

--- a/packages/framework/lib/commands/ping.ts
+++ b/packages/framework/lib/commands/ping.ts
@@ -13,3 +13,5 @@ export class PingCommand extends Command {
         // comment to shut up eslint error
     }
 }
+
+export default PingCommand;

--- a/packages/framework/lib/inhibitors/allowedIn.ts
+++ b/packages/framework/lib/inhibitors/allowedIn.ts
@@ -23,3 +23,5 @@ export class AllowedInInhibitor extends Inhibitor {
         // shut up eslint
     }
 }
+
+export default AllowedInInhibitor;

--- a/packages/framework/lib/inhibitors/cooldown.ts
+++ b/packages/framework/lib/inhibitors/cooldown.ts
@@ -50,3 +50,5 @@ export interface Cooldown {
     used: number;
     timestamp: number;
 }
+
+export default CooldownInhibitor;

--- a/packages/framework/lib/monitors/commands.ts
+++ b/packages/framework/lib/monitors/commands.ts
@@ -20,7 +20,7 @@ export class CommandsMonitor extends Monitor {
             else if (message.content.startsWith(this.client.botMention)) prefix = this.client.botMention;
         }
         // IF NO PREFIX IS USED, CANCEL
-        else if (!message.content.startsWith(prefix)) return;
+        if (!message.content.startsWith(prefix)) return;
 
         // `!ping testing` becomes `ping`
         const [commandName, ...parameters] = message.content.substring(prefix.length).split(" ");
@@ -98,7 +98,7 @@ export class CommandsMonitor extends Monitor {
                 if (!(await this.commandAllowed(message, command))) return;
 
                 await command.execute?.(message, args);
-                return this.logCommand(message, "Success", command.name);
+                return this.logCommand(message, "Success", command.parentCommand ? `${command.parentCommand}-${command.name}` :command.name);
             }
 
             // A subcommand was asked for in this command

--- a/packages/framework/lib/monitors/commands.ts
+++ b/packages/framework/lib/monitors/commands.ts
@@ -98,7 +98,7 @@ export class CommandsMonitor extends Monitor {
                 if (!(await this.commandAllowed(message, command))) return;
 
                 await command.execute?.(message, args);
-                return this.logCommand(message, "Success", command.parentCommand ? `${command.parentCommand}-${command.name}` :command.name);
+                return this.logCommand(message, "Success", command.parentCommand ? `${command.parentCommand}-${command.name}` : command.name);
             }
 
             // A subcommand was asked for in this command

--- a/packages/framework/lib/monitors/commands.ts
+++ b/packages/framework/lib/monitors/commands.ts
@@ -202,3 +202,5 @@ export class CommandsMonitor extends Monitor {
         return void 0;
     }
 }
+
+export default CommandsMonitor;

--- a/packages/framework/lib/monitors/messageCollector.ts
+++ b/packages/framework/lib/monitors/messageCollector.ts
@@ -26,3 +26,5 @@ export class MessageCollectorMonitor extends Monitor {
         // shut up eslint
     }
 }
+
+export default MessageCollectorMonitor;

--- a/packages/framework/lib/structures/Argument.ts
+++ b/packages/framework/lib/structures/Argument.ts
@@ -11,3 +11,5 @@ export abstract class Argument {
     abstract execute(argument: CommandArgument, parameters: string[], message: Message, command: Command): Promise<unknown> | unknown;
     abstract init(): Promise<unknown> | unknown;
 }
+
+export default Argument;

--- a/packages/framework/lib/structures/Command.ts
+++ b/packages/framework/lib/structures/Command.ts
@@ -53,3 +53,5 @@ export interface CommandArgument {
     /** If the type is a number, you can use this to allow/disable non-integers. By default this is false. */
     allowDecimals?: boolean;
 }
+
+export default Command;

--- a/packages/framework/lib/structures/Inhibitor.ts
+++ b/packages/framework/lib/structures/Inhibitor.ts
@@ -11,3 +11,5 @@ export abstract class Inhibitor {
     abstract execute(message: Message, command: Command): Promise<boolean> | boolean;
     abstract init(): Promise<unknown> | unknown;
 }
+
+export default Inhibitor;

--- a/packages/framework/lib/structures/Monitor.ts
+++ b/packages/framework/lib/structures/Monitor.ts
@@ -19,3 +19,5 @@ export abstract class Monitor {
     abstract execute(message: Message): Promise<unknown> | unknown;
     abstract init(): Promise<unknown> | unknown;
 }
+
+export default Monitor;

--- a/packages/framework/lib/utils/walk.ts
+++ b/packages/framework/lib/utils/walk.ts
@@ -20,3 +20,5 @@ export async function* walk(dir: string): AsyncGenerator<any, any, unknown> {
     // LOAD DIRECTORIES AFTER FILES TO ALLOW SUBCOMMANDS TO HAVE COMMAND FILES MADE FIRST!
     for (const directory of directories) yield* walk(directory);
 }
+
+export default walk;


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

- Fixes a bug where file name was only removing `ts` and not `.ts`
- Fixes a bug that when you DO have a botMention, the `else if` never runs. Changed to `if` so prefix is always verified
Status
- Fixes a bug with default exports for js users

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
