### PR TITLE
fix: removeMemberOnLeave cache option

### DIFF
--- a/.changeset/gold-candles-smash.md
+++ b/.changeset/gold-candles-smash.md
@@ -1,0 +1,5 @@
+---
+"guilded.js": patch
+---
+
+fix: removeMemberOnLeave cache option

--- a/packages/guilded.js/lib/gateway/handler/TeamMemberEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamMemberEventHandler.ts
@@ -27,8 +27,8 @@ export class TeamMemberEventHandler extends GatewayEventHandler {
         return this.client.emit(constants.clientEvents.TEAM_MEMBER_JOINED, newMember);
     }
     teamMemberRemoved(data: WSTeamMemberRemovedPayload): boolean {
-        if (this.client.options.cache?.removeMemberOnLeave) this.client.members.cache.delete(data.d.userId);
         const existingMember = this.client.members.cache.get(TeamMemberEventHandler.buildMemberKey(data.d.serverId, data.d.userId));
+        if (this.client.options.cache?.removeMemberOnLeave) this.client.members.cache.delete(TeamMemberEventHandler.buildMemberKey(data.d.serverId, data.d.userId));
         return this.client.emit(
             constants.clientEvents.TEAM_MEMBER_REMOVED,
             existingMember?._update({ kicked: data.d.isKick, banned: data.d.isBan }) ?? data.d,

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -111,7 +111,7 @@ interface ClientOptions {
         proxyURL?: string;
     };
     cache?: {
-        structureBuilder: <K, V>() => CacheStructure<K, V>;
+        structureBuilder?: <K, V>() => CacheStructure<K, V>;
         removeMemberOnLeave?: boolean;
         removeMemberBanOnUnban?: boolean;
         cacheMemberBans?: boolean;


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
Fixed the removeMemberOnLeave cache option, previously it didn't use the proper member key

I also marked structureBuilder as optional.

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
