### PR TITLE
feat: rolesUpdated event

### DIFF
--- a/.changeset/clever-gifts-count.md
+++ b/.changeset/clever-gifts-count.md
@@ -1,0 +1,6 @@
+---
+"@guildedjs/guilded-api-typings": minor
+"guilded.js": minor
+---
+
+feat: rolesUpdated event

--- a/packages/guilded-api-typings/lib/v1/structs/Member.ts
+++ b/packages/guilded-api-typings/lib/v1/structs/Member.ts
@@ -18,3 +18,8 @@ export interface TeamMemberBanPayload {
     createdBy: string;
     createdAt: string;
 }
+
+export interface TeamMemberRoleIdsPayload {
+    userId: string;
+    roleIds: number[];
+}

--- a/packages/guilded-api-typings/lib/v1/ws/Events.ts
+++ b/packages/guilded-api-typings/lib/v1/ws/Events.ts
@@ -1,4 +1,4 @@
-import type { ChatMessagePayload, TeamMemberBanPayload, TeamMemberPayload } from "../structs";
+import type { ChatMessagePayload, TeamMemberBanPayload, TeamMemberPayload, TeamMemberRoleIdsPayload } from "../structs";
 import type { WebhookPayload } from "../structs/Webhook";
 
 export enum WSOpCodes {
@@ -123,7 +123,7 @@ export interface WSTeamMemberUnbannedPayload extends SkeletonWSPayload {
 export interface WSTeamRolesUpdatedPayload extends SkeletonWSPayload {
     d: {
         serverId: string;
-        memberRoleIds: unknown[];
+        memberRoleIds: TeamMemberRoleIdsPayload[];
     };
     t: WSEvent["teamRolesUpdated"];
 }

--- a/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
@@ -1,13 +1,14 @@
 import type { WSTeamRolesUpdatedPayload } from "@guildedjs/guilded-api-typings";
 import { constants } from "../../constants";
 import { GatewayEventHandler } from "./GatewayEventHandler";
+import { buildMemberKey } from "../../util";
 
 export class TeamEventHandler extends GatewayEventHandler {
     teamRolesUpdated(data: WSTeamRolesUpdatedPayload): boolean {
         const newMembers = [];
         const oldMembers = [];
         for (const m of data.d.memberRoleIds) {
-            const member = this.client.members.cache.get(`${data.d.serverId}:${m.userId}`);
+            const member = this.client.members.cache.get(buildMemberKey(data.d.serverId, m.userId));
             if (!member) {
                 newMembers.push({ ...m, serverId: data.d.serverId });
                 continue;

--- a/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
@@ -15,6 +15,6 @@ export class TeamEventHandler extends GatewayEventHandler {
             oldMembers.push(member._clone());
             newMembers.push(member._update({ roleIds: m.roleIds }));
         }
-        return this.client.emit(constants.clientEvents.TEAM_ROLES_UPATED, data.d.serverId, newMembers, oldMembers)
+        return this.client.emit(constants.clientEvents.TEAM_ROLES_UPATED, newMembers, oldMembers)
     }
 }

--- a/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
@@ -9,7 +9,7 @@ export class TeamEventHandler extends GatewayEventHandler {
         for (const m of data.d.memberRoleIds) {
             const member = this.client.members.cache.get(`${data.d.serverId}:${m.userId}`);
             if (!member) {
-                newMembers.push({ …m, serverId: data.d.serverId });
+                newMembers.push({ ...m, serverId: data.d.serverId });
                 continue;
             }
             oldMembers.push(member._clone());

--- a/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
@@ -9,7 +9,7 @@ export class TeamEventHandler extends GatewayEventHandler {
         for (const m of data.d.memberRoleIds) {
             const member = this.client.members.cache.get(`${data.d.serverId}:${m.userId}`);
             if (!member) {
-                newMembers.push(m);
+                newMembers.push({ …m, serverId: data.d.serverId });
                 continue;
             }
             oldMembers.push(member._clone());

--- a/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamEventHandler.ts
@@ -1,8 +1,20 @@
 import type { WSTeamRolesUpdatedPayload } from "@guildedjs/guilded-api-typings";
+import { constants } from "../../constants";
 import { GatewayEventHandler } from "./GatewayEventHandler";
 
 export class TeamEventHandler extends GatewayEventHandler {
     teamRolesUpdated(data: WSTeamRolesUpdatedPayload): boolean {
-        return false;
+        const newMembers = [];
+        const oldMembers = [];
+        for (const m of data.d.memberRoleIds) {
+            const member = this.client.members.cache.get(`${data.d.serverId}:${m.userId}`);
+            if (!member) {
+                newMembers.push(m);
+                continue;
+            }
+            oldMembers.push(member._clone());
+            newMembers.push(member._update({ roleIds: m.roleIds }));
+        }
+        return this.client.emit(constants.clientEvents.TEAM_ROLES_UPATED, data.d.serverId, newMembers, oldMembers)
     }
 }

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -134,6 +134,6 @@ type ClientEvents = {
     memberUnbanned: (member: MemberBan | WSTeamMemberUnbannedPayload["d"]) => unknown;
     webhookCreated: (webhook: Webhook) => unknown;
     webhookUpdated: (webhook: Webhook, oldWebhook: Webhook | null) => unknown;
-    rolesUpdated: (serverId: string, members: (Member | TeamMemberRoleIdsPayload)[], oldMembers: Member[]) => unknown;
+    rolesUpdated: (members: (Member | TeamMemberRoleIdsPayload)[], oldMembers: Member[]) => unknown;
     unknownGatewayEvent: (data: any) => unknown;
 };

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -20,9 +20,9 @@ import type {
     WSTeamMemberRemovedPayload,
     WSTeamMemberUnbannedPayload,
     WSTeamMemberUpdatedPayload,
+    TeamMemberRoleIdsPayload,
 } from "@guildedjs/guilded-api-typings";
 import type { Member, MemberBan } from "./Member";
-import type { Role } from "./Role";
 import type { CacheStructure } from "../cache";
 import { GlobalWebhookManager } from "../managers/global/WebhookManager";
 import type { Webhook } from "./Webhook";
@@ -134,6 +134,6 @@ type ClientEvents = {
     memberUnbanned: (member: MemberBan | WSTeamMemberUnbannedPayload["d"]) => unknown;
     webhookCreated: (webhook: Webhook) => unknown;
     webhookUpdated: (webhook: Webhook, oldWebhook: Webhook | null) => unknown;
-    teamRolesUpdated: (roleIds: Role[] | number[]) => unknown;
+    rolesUpdated: (serverId: string, members: (Member | TeamMemberRoleIdsPayload)[], oldMembers: Member[]) => unknown;
     unknownGatewayEvent: (data: any) => unknown;
 };

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -134,6 +134,6 @@ type ClientEvents = {
     memberUnbanned: (member: MemberBan | WSTeamMemberUnbannedPayload["d"]) => unknown;
     webhookCreated: (webhook: Webhook) => unknown;
     webhookUpdated: (webhook: Webhook, oldWebhook: Webhook | null) => unknown;
-    rolesUpdated: (members: (Member | TeamMemberRoleIdsPayload)[], oldMembers: Member[]) => unknown;
+    rolesUpdated: (members: (Member | TeamMemberRoleIdsPayload & { serverId: string })[], oldMembers: Member[]) => unknown;
     unknownGatewayEvent: (data: any) => unknown;
 };


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Implemented the teamRolesUpdated event.

Some things I'm not sure of:
1. The `TEAM_ROLES_UPDATED` constant is `rolesUpdated`, whereas in the `ClientEvents` type it was `teamRolesUpdated`. I chose to go with rolesUpdated for consistency with the lib since other events omitted "team"
2. The changeset here minor bumps both guilded.js and guilded-api-typings

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
