### PR TITLE
feat: get cache before fetching, optional force

### DIFF
--- a/.changeset/three-oranges-call.md
+++ b/.changeset/three-oranges-call.md
@@ -1,0 +1,5 @@
+---
+"guilded.js": minor
+---
+
+feat: get cache before fetching, optional force

--- a/packages/guilded.js/lib/managers/global/GuildBanManager.ts
+++ b/packages/guilded.js/lib/managers/global/GuildBanManager.ts
@@ -5,10 +5,10 @@ import { buildMemberKey } from "../../util";
 
 export class GlobalGuildBanManager extends CacheableStructManager<string, MemberBan> {
     /** Fetch a member ban in a server */
-    async fetch(serverId: string, userId: string, force?: boolean): Promise<MemberBan> {
+    fetch(serverId: string, userId: string, force?: boolean): Promise<MemberBan> {
         if (!force) {
             const existingMemberBan = this.client.bans.cache.get(buildMemberKey(serverId, userId));
-            if (existingMemberBan) return existingMemberBan;
+            if (existingMemberBan) return Promise.resolve(existingMemberBan);
         }
         return this.client.rest.router.getMemberBan(serverId, userId).then((data) => {
             const newMemberBan = new MemberBan(this.client, { ...data.serverMemberBan, serverId });

--- a/packages/guilded.js/lib/managers/global/GuildBanManager.ts
+++ b/packages/guilded.js/lib/managers/global/GuildBanManager.ts
@@ -5,7 +5,11 @@ import { buildMemberKey } from "../../util";
 
 export class GlobalGuildBanManager extends CacheableStructManager<string, MemberBan> {
     /** Fetch a member ban in a server */
-    fetch(serverId: string, userId: string): Promise<MemberBan> {
+    async fetch(serverId: string, userId: string, force?: boolean): Promise<MemberBan> {
+        if (!force) {
+            const existingMemberBan = this.client.bans.cache.get(buildMemberKey(serverId, userId));
+            if (existingMemberBan) return existingMemberBan;
+        }
         return this.client.rest.router.getMemberBan(serverId, userId).then((data) => {
             const newMemberBan = new MemberBan(this.client, { ...data.serverMemberBan, serverId });
             if (this.client.options.cache?.cacheMemberBans !== false) this.client.bans.cache.set(newMemberBan.id, newMemberBan);

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -7,11 +7,11 @@ import { buildMemberKey } from "../../util";
 
 export class GlobalMemberManager extends CacheableStructManager<string, Member> {
     /** Fetch a member from a server */
-    async fetch(serverId: string, memberId: string, force?: boolean): Promise<Member> {
+    fetch(serverId: string, memberId: string, force?: boolean): Promise<Member> {
         const memberKey = buildMemberKey(serverId, memberId);
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);
-            if (existingMember) return existingMember;
+            if (existingMember) return Promise.resolve(existingMember);
         }
         return this.client.rest.router.getMember(serverId, memberId).then((data) => {
             const newMember = new Member(this.client, { ...data.member, serverId, id: data.member.user.id });

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -7,11 +7,16 @@ import { buildMemberKey } from "../../util";
 
 export class GlobalMemberManager extends CacheableStructManager<string, Member> {
     /** Fetch a member from a server */
-    fetch(serverId: string, memberId: string): Promise<Member> {
+    async fetch(serverId: string, memberId: string, force?: boolean): Promise<Member> {
+        const memberKey = buildMemberKey(serverId, memberId);
+        if (!force) {
+            const existingMember = this.client.members.cache.get(memberKey);
+            if (existingMember) return existingMember;
+        }
         return this.client.rest.router.getMember(serverId, memberId).then((data) => {
             const newMember = new Member(this.client, { ...data.member, serverId, id: data.member.user.id });
             this.client.users.cache.set(data.member.user.id, new User(this.client, data.member.user));
-            this.client.members.cache.set(buildMemberKey(serverId, newMember.id), newMember);
+            this.client.members.cache.set(memberKey, newMember);
             return newMember;
         });
     }

--- a/packages/guilded.js/lib/managers/global/MessageManager.ts
+++ b/packages/guilded.js/lib/managers/global/MessageManager.ts
@@ -17,7 +17,11 @@ export class GlobalMessageManager extends CacheableStructManager<string, Message
     }
 
     /** Get details for a specific chat message from a chat channel. */
-    fetch(channelId: string, messageId: string): Promise<Message> {
+    async fetch(channelId: string, messageId: string, force?: boolean): Promise<Message> {
+        if (!force) {
+            const existingMessage = this.client.messages.cache.get(messageId);
+            if (existingMessage) return existingMessage;
+        }
         return this.client.rest.router.getChannelMessage(channelId, messageId).then((data) => {
             const newMessage = new Message(this.client, data.message);
             this.client.messages.cache.set(newMessage.id, newMessage);

--- a/packages/guilded.js/lib/managers/global/MessageManager.ts
+++ b/packages/guilded.js/lib/managers/global/MessageManager.ts
@@ -17,10 +17,10 @@ export class GlobalMessageManager extends CacheableStructManager<string, Message
     }
 
     /** Get details for a specific chat message from a chat channel. */
-    async fetch(channelId: string, messageId: string, force?: boolean): Promise<Message> {
+    fetch(channelId: string, messageId: string, force?: boolean): Promise<Message> {
         if (!force) {
             const existingMessage = this.client.messages.cache.get(messageId);
-            if (existingMessage) return existingMessage;
+            if (existingMessage) return Promise.resolve(existingMessage);
         }
         return this.client.rest.router.getChannelMessage(channelId, messageId).then((data) => {
             const newMessage = new Message(this.client, data.message);

--- a/packages/guilded.js/lib/managers/global/WebhookManager.ts
+++ b/packages/guilded.js/lib/managers/global/WebhookManager.ts
@@ -34,7 +34,11 @@ export class GlobalWebhookManager extends CacheableStructManager<string, Webhook
     }
 
     /** Get a webhook */
-    getWebhook(serverId: string, webhookId: string): Promise<Webhook> {
+    async getWebhook(serverId: string, webhookId: string, force?: boolean): Promise<Webhook> {
+        if (!force) {
+            const existingWebhook = this.client.webhooks.cache.get(webhookId);
+            if (existingWebhook) return existingWebhook;
+        }
         return this.client.rest.router.getWebhook(serverId, webhookId).then((data) => {
             const newWebhook = new Webhook(this.client, data.webhook);
             if (this._shouldCacheWebhook) this.cache.set(newWebhook.id, newWebhook);

--- a/packages/guilded.js/lib/managers/global/WebhookManager.ts
+++ b/packages/guilded.js/lib/managers/global/WebhookManager.ts
@@ -34,10 +34,10 @@ export class GlobalWebhookManager extends CacheableStructManager<string, Webhook
     }
 
     /** Get a webhook */
-    async getWebhook(serverId: string, webhookId: string, force?: boolean): Promise<Webhook> {
+    getWebhook(serverId: string, webhookId: string, force?: boolean): Promise<Webhook> {
         if (!force) {
             const existingWebhook = this.client.webhooks.cache.get(webhookId);
-            if (existingWebhook) return existingWebhook;
+            if (existingWebhook) return Promise.resolve(existingWebhook);
         }
         return this.client.rest.router.getWebhook(serverId, webhookId).then((data) => {
             const newWebhook = new Webhook(this.client, data.webhook);


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Uses cached data before attempting to fetch. If force is true, the cache check is skipped

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
