### PR TITLE
fix: invalid CommandArgument '...strings'

### DIFF
--- a/.changeset/gold-tips-rest.md
+++ b/.changeset/gold-tips-rest.md
@@ -1,0 +1,5 @@
+---
+"@guildedjs/gil": patch
+---
+
+fix: invalid CommandArgument '...strings'

--- a/packages/framework/lib/structures/Command.ts
+++ b/packages/framework/lib/structures/Command.ts
@@ -35,7 +35,7 @@ export interface CommandArgument {
     /** The name of the argument. Useful for when you need to alert the user X arg is missing. */
     name: string;
     /** The type of the argument you would like. Defaults to string. */
-    type?: "number" | "string" | "...strings" | "boolean" | "duration" | "subcommand";
+    type?: "number" | "string" | "...string" | "boolean" | "duration" | "subcommand";
     /** The function that runs if this argument is required and is missing. */
     missing?: (message: Message) => unknown;
     /** Whether or not this argument is required. Defaults to true. */


### PR DESCRIPTION
The [CommandArgument structure interface](https://github.com/guildedjs/guilded.js/blob/ee12105fde04b906e8ffa1bf41c1bcfb3736cc74/packages/framework/lib/structures/Command.ts#L38) expects `...strings` but the [actual argument](https://github.com/guildedjs/guilded.js/blob/main/packages/framework/lib/arguments/...string.ts) requires `...string`.

As such, trying to use `...string` with the arguments will result in it being considered an invalid type and fail to output the expected result.

Expected Input structure:
``` typescript
    arguments = [{
        name: "subcommand",
        type: "string",
      }, 
      {
        name: "text",
        type: "...strings",
      }] as const
```
Output result:
_Missing `text` argument_
``` typescript
{
  subcommand: 'add' 
}
```

Corrected Input structure:
``` typescript
    arguments = [{
        name: "subcommand",
        type: "string",
      }, 
      {
        name: "text",
        type: "...string",
      }] as const
```
Output result:
_`text` argument appears in `args` as expected._
``` typescript
{    
  subcommand: 'add',
  text: 'This is a test'
}
```

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
