### PR TITLE
feat: add isSilent to message body

### DIFF
--- a/.changeset/eight-lizards-carry.md
+++ b/.changeset/eight-lizards-carry.md
@@ -1,0 +1,7 @@
+---
+"@guildedjs/guilded-api-typings": patch
+"guilded.js": patch
+"@guildedjs/rest": patch
+---
+
+feat: add isSilent to post message body

--- a/packages/guilded-api-typings/lib/v1/rest/Message.ts
+++ b/packages/guilded-api-typings/lib/v1/rest/Message.ts
@@ -10,6 +10,8 @@ export interface RESTPostChannelMessagesResult {
 export interface RESTPostChannelMessagesBody {
     /** Whether the message can only be seen by those mentioned or replied to */
     isPrivate?: boolean;
+    /** If set, this message will not notify any mentioned users or roles. */
+    isSilent?: boolean;
     /** The id(s) of the messages this message is a reply to */
     replyMessageIds?: string[];
     /** The message content. */

--- a/packages/guilded-api-typings/lib/v1/structs/Message.ts
+++ b/packages/guilded-api-typings/lib/v1/structs/Message.ts
@@ -1,12 +1,3 @@
-export interface ChatMessageContent {
-    /** If set, this message will only be seen by those mentioned or replied to. */
-    isPrivate?: boolean;
-    /** The ids of the messages that this will be replying to. */
-    replyMessageIds?: string[];
-    /** The message content to create. */
-    content: string;
-}
-
 export interface ChatMessagePayload {
     /** The id of the message */
     id: string;

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -105,6 +105,6 @@ export class Message extends Base<ChatMessagePayload> {
     /** Send a message that replies to this message. It mentions the user who sent this message. */
     reply(content: RESTPostChannelMessagesBody | string) {
         if (typeof content === "string") content = { content };
-        return this.client.messages.send(this.channelId, { content: content.content, replyMessageIds: content.replyMessageIds ?? [this.id] });
+        return this.client.messages.send(this.channelId, { ...content, replyMessageIds: content.replyMessageIds ?? [this.id] });
     }
 }

--- a/packages/guilded.js/lib/structures/channels/Channel.ts
+++ b/packages/guilded.js/lib/structures/channels/Channel.ts
@@ -1,11 +1,11 @@
 import type Collection from "@discordjs/collection";
-import type { ChatMessageContent, RESTGetChannelMessagesQuery } from "@guildedjs/guilded-api-typings";
+import type { RESTPostChannelMessagesBody, RESTGetChannelMessagesQuery } from "@guildedjs/guilded-api-typings";
 import { Base } from "../Base";
 import type { Message } from "../Message";
 
 export class Channel extends Base {
     /** Send a message to this channel. */
-    send(content: ChatMessageContent | string): Promise<Message> {
+    send(content: RESTPostChannelMessagesBody | string): Promise<Message> {
         return this.client.messages.send(this.id, content);
     }
 

--- a/packages/rest/lib/util/Router.ts
+++ b/packages/rest/lib/util/Router.ts
@@ -1,5 +1,4 @@
 import type {
-    ChatMessageContent,
     RESTDeleteChannelMessageResult,
     RESTDeleteDocResult,
     RESTDeleteGroupMemberResult,
@@ -63,7 +62,7 @@ export class Router {
     constructor(public readonly rest: RestManager) {}
 
     /** Send a message to a channel */
-    createChannelMessage(channelId: string, content: ChatMessageContent | string): Promise<RESTPostChannelMessagesResult> {
+    createChannelMessage(channelId: string, content: RESTPostChannelMessagesBody | string): Promise<RESTPostChannelMessagesResult> {
         if (typeof content === "string") content = { content };
 
         return this.rest.post<RESTPostChannelMessagesResult, RESTPostChannelMessagesBody>(ROUTES.channelMessages(channelId), content);


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Added `isSilent`. Also, I removed `ChatMessageContent` in favor of `RESTPostChannelMessagesBody` because I don't see the point of duplicate interfaces.

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
