### PR TITLE
message content should only pass sole object

### DIFF
--- a/packages/gil/lib/commands/ping.ts
+++ b/packages/gil/lib/commands/ping.ts
@@ -6,7 +6,7 @@ export class PingCommand extends Command {
     name = "ping";
 
     execute(message: Message): any {
-        return this.client.messages.send(message.channelId, "Pong");
+        return this.client.messages.send(message.channelId, { content: "Pong" });
     }
 
     init(): void {

--- a/packages/guilded.js/README.md
+++ b/packages/guilded.js/README.md
@@ -16,7 +16,7 @@ const client = new Client({ token: "TOKEN_HERE" });
 client.on("ready", () => console.log(`Bot is successfully logged in`));
 client.on("messageCreated", (message) => {
     if (message.content === "poggers") {
-        return message.reply("test indeed");
+        return message.reply({ content: "test indeed" });
     }
 });
 

--- a/packages/guilded.js/lib/managers/global/MessageManager.ts
+++ b/packages/guilded.js/lib/managers/global/MessageManager.ts
@@ -30,7 +30,7 @@ export class GlobalMessageManager extends CacheableStructManager<string, Message
     }
 
     /** Send a message in a channel */
-    send(channelId: string, content: RESTPostChannelMessagesBody | string): Promise<Message> {
+    send(channelId: string, content: RESTPostChannelMessagesBody): Promise<Message> {
         return this.client.rest.router.createChannelMessage(channelId, content).then((data) => {
             // This is in the case of which the WS gateway beats us to adding the message to the cache. If they haven't, then we do it ourselves.
             const existingMessage = this.client.messages.cache.get(data.message.id);
@@ -47,8 +47,8 @@ export class GlobalMessageManager extends CacheableStructManager<string, Message
     }
 
     /** Update a channel message. */
-    update(channelId: string, messageId: string, content: string): Promise<Message> {
-        return this.client.rest.router.updateChannelMessage(channelId, messageId, { content }).then((data) => {
+    update(channelId: string, messageId: string, content: RESTPostChannelMessagesBody): Promise<Message> {
+        return this.client.rest.router.updateChannelMessage(channelId, messageId, content).then((data) => {
             // This is in the case of which the WS gateway beats us to modifying the message in the cache. If they haven't, then we do it ourselves.
             const existingMessage = this.client.messages.cache.get(data.message.id);
             if (existingMessage) return existingMessage._update(data.message);

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -93,18 +93,17 @@ export class Message extends Base<ChatMessagePayload> {
     }
 
     /* Update message content */
-    update(newContent: string): Promise<Message> {
+    update(newContent: RESTPostChannelMessagesBody): Promise<Message> {
         return this.client.messages.update(this.channelId, this.id, newContent).then(() => this);
     }
 
     /** Send a message in the same channel as this message. */
-    send(content: RESTPostChannelMessagesBody | string) {
+    send(content: RESTPostChannelMessagesBody) {
         return this.client.messages.send(this.channelId, content);
     }
 
     /** Send a message that replies to this message. It mentions the user who sent this message. */
-    reply(content: RESTPostChannelMessagesBody | string) {
-        if (typeof content === "string") content = { content };
+    reply(content: RESTPostChannelMessagesBody) {
         return this.client.messages.send(this.channelId, { ...content, replyMessageIds: content.replyMessageIds ?? [this.id] });
     }
 }

--- a/packages/guilded.js/lib/structures/channels/Channel.ts
+++ b/packages/guilded.js/lib/structures/channels/Channel.ts
@@ -5,7 +5,7 @@ import type { Message } from "../Message";
 
 export class Channel extends Base {
     /** Send a message to this channel. */
-    send(content: RESTPostChannelMessagesBody | string): Promise<Message> {
+    send(content: RESTPostChannelMessagesBody): Promise<Message> {
         return this.client.messages.send(this.id, content);
     }
 
@@ -20,7 +20,7 @@ export class Channel extends Base {
     }
 
     /** Update a channel message. */
-    updateMessage(messageId: string, content: string): Promise<Message> {
+    updateMessage(messageId: string, content: RESTPostChannelMessagesBody): Promise<Message> {
         return this.client.messages.update(this.id, messageId, content);
     }
 

--- a/packages/rest/lib/util/Router.ts
+++ b/packages/rest/lib/util/Router.ts
@@ -62,9 +62,7 @@ export class Router {
     constructor(public readonly rest: RestManager) {}
 
     /** Send a message to a channel */
-    createChannelMessage(channelId: string, content: RESTPostChannelMessagesBody | string): Promise<RESTPostChannelMessagesResult> {
-        if (typeof content === "string") content = { content };
-
+    createChannelMessage(channelId: string, content: RESTPostChannelMessagesBody): Promise<RESTPostChannelMessagesResult> {
         return this.rest.post<RESTPostChannelMessagesResult, RESTPostChannelMessagesBody>(ROUTES.channelMessages(channelId), content);
     }
 


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
1. Since embeds are now released on guilded api, this should just make sense to do,
for example:
message.send({ embeds: [embed] })
message.send({ content: 'ping' })
message.send({ content: 'ping', embeds: [embed] })
2. This is also for parity with discord.js since this library is heavily inspired by it
3. Also makes message.reply and message.update use objects since those only use strings for some reason

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
