### PR TITLE
fix: allow object for updating message content

### DIFF
--- a/packages/guilded.js/lib/managers/global/MessageManager.ts
+++ b/packages/guilded.js/lib/managers/global/MessageManager.ts
@@ -47,8 +47,9 @@ export class GlobalMessageManager extends CacheableStructManager<string, Message
     }
 
     /** Update a channel message. */
-    update(channelId: string, messageId: string, content: string): Promise<Message> {
-        return this.client.rest.router.updateChannelMessage(channelId, messageId, { content }).then((data) => {
+    update(channelId: string, messageId: string, content: RESTPostChannelMessagesBody | string): Promise<Message> {
+        if (typeof content === "string") content = { content };
+        return this.client.rest.router.updateChannelMessage(channelId, messageId, content).then((data) => {
             // This is in the case of which the WS gateway beats us to modifying the message in the cache. If they haven't, then we do it ourselves.
             const existingMessage = this.client.messages.cache.get(data.message.id);
             if (existingMessage) return existingMessage._update(data.message);

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -93,7 +93,7 @@ export class Message extends Base<ChatMessagePayload> {
     }
 
     /* Update message content */
-    update(newContent: string): Promise<Message> {
+    update(newContent: RESTPostChannelMessagesBody | string): Promise<Message> {
         return this.client.messages.update(this.channelId, this.id, newContent).then(() => this);
     }
 

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -105,6 +105,6 @@ export class Message extends Base<ChatMessagePayload> {
     /** Send a message that replies to this message. It mentions the user who sent this message. */
     reply(content: RESTPostChannelMessagesBody | string) {
         if (typeof content === "string") content = { content };
-        return this.client.messages.send(this.channelId, { ...content, replyMessageIds: [this.id] });
+        return this.client.messages.send(this.channelId, { ...content, replyMessageIds: content.replyMessageIds ? [this.id, ...content.replyMessageIds] : [this.id] });
     }
 }

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -105,6 +105,6 @@ export class Message extends Base<ChatMessagePayload> {
     /** Send a message that replies to this message. It mentions the user who sent this message. */
     reply(content: RESTPostChannelMessagesBody | string) {
         if (typeof content === "string") content = { content };
-        return this.client.messages.send(this.channelId, { ...content, replyMessageIds: content.replyMessageIds ?? [this.id] });
+        return this.client.messages.send(this.channelId, { ...content, replyMessageIds: [this.id] });
     }
 }

--- a/packages/guilded.js/lib/structures/channels/Channel.ts
+++ b/packages/guilded.js/lib/structures/channels/Channel.ts
@@ -20,7 +20,7 @@ export class Channel extends Base {
     }
 
     /** Update a channel message. */
-    updateMessage(messageId: string, content: string): Promise<Message> {
+    updateMessage(messageId: string, content: RESTPostChannelMessagesBody | string): Promise<Message> {
         return this.client.messages.update(this.id, messageId, content);
     }
 


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
This PR lets users update messages by passing objects through message.update, for example a use case for this would be:

```js
const embed = new Embed().setTitle('1');
const msg = await message.reply({ embeds: [embed] })
embed.setTitle('2')
msg.update({ embeds: [embed] })
```

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
