### PR TITLE
fix: constructors should not insert in sets

### DIFF
--- a/packages/gil/lib/structures/Argument.ts
+++ b/packages/gil/lib/structures/Argument.ts
@@ -4,9 +4,7 @@ import type { BotClient } from "../BotClient";
 import type { Command, CommandArgument } from "./Command";
 
 export abstract class Argument {
-    constructor(public readonly client: BotClient, public name: string) {
-        this.client.arguments.set(name, this);
-    }
+    constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(argument: CommandArgument, parameters: string[], message: Message, command: Command): Promise<unknown> | unknown;
     abstract init(): Promise<unknown> | unknown;

--- a/packages/gil/lib/structures/Command.ts
+++ b/packages/gil/lib/structures/Command.ts
@@ -23,9 +23,7 @@ export abstract class Command {
     /** The name of the parent command. If nested subcommands, use `-` to separate the names. For example: `.settings staff modrole` would be parentCommand: "settings-staff" */
     parentCommand?: string;
 
-    constructor(public readonly client: BotClient, public name: string) {
-        this.client.commands.set(name, this);
-    }
+    constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message, args: Record<string, unknown>): Promise<unknown> | unknown;
     abstract init(): Promise<unknown> | unknown;

--- a/packages/gil/lib/structures/Inhibitor.ts
+++ b/packages/gil/lib/structures/Inhibitor.ts
@@ -4,9 +4,7 @@ import type { BotClient } from "../BotClient";
 import type { Command } from "./Command";
 
 export abstract class Inhibitor {
-    constructor(public readonly client: BotClient, public name: string) {
-        this.client.inhibitors.set(name, this);
-    }
+    constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message, command: Command): Promise<boolean> | boolean;
     abstract init(): Promise<unknown> | unknown;

--- a/packages/gil/lib/structures/Monitor.ts
+++ b/packages/gil/lib/structures/Monitor.ts
@@ -12,9 +12,7 @@ export abstract class Monitor {
     /** Whether this monitor should ignore messages that are sent in DM. By default this is true. */
     ignoreDM = true;
 
-    constructor(public readonly client: BotClient, public name: string) {
-        this.client.monitors.set(name, this);
-    }
+    constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message): Promise<unknown> | unknown;
     abstract init(): Promise<unknown> | unknown;


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

- Fixes a small bug where subcommand were inserted with the name of the command into the set.
 
Status

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
