### PR TITLE
chore: enable new-line-between-members

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
         "@typescript-eslint/explicit-function-return-type": "error",
         "@typescript-eslint/explicit-member-accessibility": "off",
         "@typescript-eslint/no-invalid-this": "off",
-        "lines-between-class-members": ["warn", "always"],
+        "@typescript-eslint/lines-between-class-members": ["warn", "always"],
         "array-callback-return": "off",
         "simple-import-sort/imports": "warn",
         "simple-import-sort/exports": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
         "@typescript-eslint/explicit-function-return-type": "error",
         "@typescript-eslint/explicit-member-accessibility": "off",
         "@typescript-eslint/no-invalid-this": "off",
+        "lines-between-class-members": ["warn", "always"],
         "array-callback-return": "off",
         "simple-import-sort/imports": "warn",
         "simple-import-sort/exports": "warn",

--- a/packages/embeds/lib/Embed.ts
+++ b/packages/embeds/lib/Embed.ts
@@ -4,13 +4,19 @@ import { resolveColor } from "./util";
 
 export class Embed {
     title: string | null;
+
     description: string | null;
+
     url: string | null;
+
     timestamp: number | null;
+
     color: number | null;
 
     image: APIEmbedMediaData | null;
+
     thumbnail: APIEmbedMediaData | null;
+
     video: APIEmbedMediaData | null;
 
     author: {

--- a/packages/gil/lib/BotClient.ts
+++ b/packages/gil/lib/BotClient.ts
@@ -13,18 +13,25 @@ import { walk } from "./utils/walk";
 export class BotClient extends Client {
     /** All your bot's monitors will be available here */
     monitors = new Collection<string, Monitor>();
+
     /** All your bot's commands will be available here */
     commands = new Collection<string, Command>();
+
     /** All your bot's arguments will be available here */
     arguments = new Collection<string, Argument>();
+
     /** All your bot's inhibitors will be available here */
     inhibitors = new Collection<string, Inhibitor>();
+
     /** All your bot's tasks will be available here */
     tasks = new Collection<string, Task>();
+
     /** The bot's prefixes per team. <teamId, prefix> */
     prefixes = new Map<string, string>();
+
     /** The message collectors that are pending. */
     messageCollectors = new Collection<string, MessageCollector>();
+
     /** The path that the end users commands,monitors, inhibitors and others will be located. */
     sourceFolderPath = this.options.sourceFolderPath || path.join(process.cwd(), "src/");
 
@@ -244,7 +251,9 @@ export class BotClient extends Client {
     }
 
     async needMessage(userId: string, channelId: string, options?: MessageCollectorOptions & { amount?: 1 }): Promise<Message>;
+
     async needMessage(userId: string, channelId: string, options: MessageCollectorOptions & { amount?: number }): Promise<Message[]>;
+
     async needMessage(userId: string, channelId: string, options?: MessageCollectorOptions): Promise<Message | Message[]> {
         const messages = await this.collectMessages({
             key: userId,

--- a/packages/gil/lib/inhibitors/cooldown.ts
+++ b/packages/gil/lib/inhibitors/cooldown.ts
@@ -6,6 +6,7 @@ import { Inhibitor } from "../structures/Inhibitor";
 
 export class CooldownInhibitor extends Inhibitor {
     name = "cooldown";
+
     /** The collection of users that are in cooldown */
     membersInCooldown = new Collection<string, Cooldown>();
 

--- a/packages/gil/lib/structures/Argument.ts
+++ b/packages/gil/lib/structures/Argument.ts
@@ -7,6 +7,7 @@ export abstract class Argument {
     constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(argument: CommandArgument, parameters: string[], message: Message, command: Command): Promise<unknown> | unknown;
+
     abstract init(): Promise<unknown> | unknown;
 }
 

--- a/packages/gil/lib/structures/Command.ts
+++ b/packages/gil/lib/structures/Command.ts
@@ -6,12 +6,16 @@ import type { BotClient } from "../BotClient";
 export abstract class Command {
     /** The command aliases are stored here. */
     aliases?: string[];
+
     /** The arguments you wish to request from the user. */
     arguments?: readonly CommandArgument[];
+
     /** Where is this command allowed to run in? By default, it is allowed to run in a server only! */
     allowedIn?: ("dm" | "server")[] = ["server"];
+
     /** The description of the command */
     description?: string;
+
     /** The cooldown settings for this command. */
     cooldown?: {
         seconds: number;
@@ -20,12 +24,14 @@ export abstract class Command {
 
     /** The subcommands for this command. */
     subcommands?: Collection<string, Command>;
+
     /** The name of the parent command. If nested subcommands, use `-` to separate the names. For example: `.settings staff modrole` would be parentCommand: "settings-staff" */
     parentCommand?: string;
 
     constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message, args: Record<string, unknown>): Promise<unknown> | unknown;
+
     abstract init(): Promise<unknown> | unknown;
 }
 

--- a/packages/gil/lib/structures/Inhibitor.ts
+++ b/packages/gil/lib/structures/Inhibitor.ts
@@ -7,6 +7,7 @@ export abstract class Inhibitor {
     constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message, command: Command): Promise<boolean> | boolean;
+
     abstract init(): Promise<unknown> | unknown;
 }
 

--- a/packages/gil/lib/structures/Monitor.ts
+++ b/packages/gil/lib/structures/Monitor.ts
@@ -5,16 +5,20 @@ import type { BotClient } from "../BotClient";
 export abstract class Monitor {
     /** Whether this monitor should ignore messages that are sent by bots. By default this is true. */
     ignoreBots = true;
+
     /** Whether this monitor should ignore messages that are sent by others. By default this is false.*/
     ignoreOthers = false;
+
     /** Whether this monitor should ignore messages that are edited. By default this is false.*/
     ignoreEdits = false;
+
     /** Whether this monitor should ignore messages that are sent in DM. By default this is true. */
     ignoreDM = true;
 
     constructor(public readonly client: BotClient, public name: string) {}
 
     abstract execute(message: Message): Promise<unknown> | unknown;
+
     abstract init(): Promise<unknown> | unknown;
 }
 

--- a/packages/gil/lib/structures/Task.ts
+++ b/packages/gil/lib/structures/Task.ts
@@ -3,13 +3,17 @@ import type { BotClient } from "../BotClient";
 export abstract class Task {
     /** The amount of time this task should take to run. Defaults to 1 hour(3,600,000 ms) */
     millisecondsInterval = 60 * 60 * 1000;
+
     /** Whether or not this task should run immediately on startup. Default to false. */
     runOnStartup = false;
+
     /** Whether this task requires the bot to be fully ready before running. Default to false. */
     requireReady = false;
 
     constructor(public readonly client: BotClient, public name: string) {}
+
     abstract execute(): Promise<unknown> | unknown;
+
     abstract init(): Promise<unknown> | unknown;
 }
 

--- a/packages/rest/lib/RestManager.ts
+++ b/packages/rest/lib/RestManager.ts
@@ -13,10 +13,13 @@ import { Router } from "./util/Router";
 export class RestManager {
     /** The bot token to be used for making requests. */
     token = this.options.token;
+
     /** The version of the API to be used for making requests. By default, this will use the latest version that the library supports. */
     version = this.options.version ?? 1;
+
     /** The proxy url if it was set. */
     proxyURL = this.options.proxyURL;
+
     /** The router with all the helper methods. */
     readonly router = new Router(this);
 

--- a/packages/webhook-client/lib/Embed.ts
+++ b/packages/webhook-client/lib/Embed.ts
@@ -4,11 +4,17 @@ import { resolveColor } from "./util";
 
 export class Embed {
     public title: string | null;
+
     public description: string | null;
+
     public url: string | null;
+
     public timestamp: number | null;
+
     public timestampString: string | null;
+
     public color: number | null;
+
     public footer: {
         text: string;
         iconURL: string | null;
@@ -16,8 +22,11 @@ export class Embed {
     } | null;
 
     public image: APIEmbedMediaData | null;
+
     public thumbnail: APIEmbedMediaData | null;
+
     public video: APIEmbedMediaData | null;
+
     public provider: {
         name: string | null;
         url: string | null;

--- a/packages/webhook-client/lib/WebhookClient.ts
+++ b/packages/webhook-client/lib/WebhookClient.ts
@@ -7,8 +7,11 @@ import { type parsedMessage, parseMessage } from "./messageUtil";
 
 export class WebhookClient {
     public URL: string;
+
     public id: string;
+
     public token: string;
+
     private rest: RestManager;
 
     public constructor(webhookConnection: string | { id: string; token: string }) {


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
This enables the https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/lines-between-class-members.md rule.

Status

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.