### PR TITLE
feat: isOwner and isSilent

### DIFF
--- a/.changeset/odd-pumpkins-sort.md
+++ b/.changeset/odd-pumpkins-sort.md
@@ -1,0 +1,6 @@
+---
+"@guildedjs/guilded-api-typings": minor
+"guilded.js": minor
+---
+
+Add isOwner and isSilent

--- a/packages/guilded-api-typings/lib/v1/rest/Message.ts
+++ b/packages/guilded-api-typings/lib/v1/rest/Message.ts
@@ -7,8 +7,7 @@ import type { ChatMessagePayload } from "../structs/Message";
 export interface RESTPostChannelMessagesResult {
     message: ChatMessagePayload;
 }
-export type RESTPostChannelMessagesBody = Pick<ChatMessagePayload, "isPrivate" | "replyMessageIds" | "embeds"> & {
-    isSilent?: boolean;
+export type RESTPostChannelMessagesBody = Pick<ChatMessagePayload, "isPrivate" | "replyMessageIds" | "embeds" | "isSilent"> & {
     content?: string;
 };
 /**

--- a/packages/guilded-api-typings/lib/v1/structs/Member.ts
+++ b/packages/guilded-api-typings/lib/v1/structs/Member.ts
@@ -5,6 +5,7 @@ export interface TeamMemberPayload {
     roleIds: number[];
     nickname?: string;
     joinedAt: string;
+    isOwner?: boolean;
 }
 
 export interface TeamMemberSummaryPayload {

--- a/packages/guilded-api-typings/lib/v1/structs/Message.ts
+++ b/packages/guilded-api-typings/lib/v1/structs/Message.ts
@@ -13,6 +13,8 @@ export interface ChatMessagePayload {
     replyMessageIds?: string[];
     /** If set, this message will only be seen by those mentioned or replied to. */
     isPrivate?: boolean;
+    /** If set, this message did not notify, mention or reply recipients. */
+    isSilent?: boolean;
     /** The ISO 8601 timestamp that the message was created at. */
     createdAt: string;
     /** The ID of the user who created this message (Note: If this event has createdByBotId or createdByWebhookId present, this field will still be populated, but can be ignored. In these cases, the value of this field will always be Ann6LewA) */

--- a/packages/guilded.js/lib/structures/Member.ts
+++ b/packages/guilded.js/lib/structures/Member.ts
@@ -18,6 +18,8 @@ export class Member extends Base<UpgradedTeamMemberPayload> {
     kicked: boolean;
     /** Whether this member has been banned */
     banned: boolean;
+    /** Whether this member owns the server */
+    isOwner: boolean;
 
     constructor(client: Client, data: UpgradedTeamMemberPayload) {
         super(client, data);
@@ -25,6 +27,7 @@ export class Member extends Base<UpgradedTeamMemberPayload> {
         this.joinedAt = new Date(data.joinedAt);
         this.kicked = false;
         this.banned = false;
+        this.isOwner = false;
 
         this._update(data);
     }
@@ -44,6 +47,10 @@ export class Member extends Base<UpgradedTeamMemberPayload> {
 
         if ("banned" in data && typeof data.banned !== "undefined") {
             this.banned = data.banned;
+        }
+
+        if ("isOwner" in data && typeof data.isOwner !== "undefined") {
+            this.isOwner == data.isOwner;
         }
 
         return this;

--- a/packages/guilded.js/lib/structures/Member.ts
+++ b/packages/guilded.js/lib/structures/Member.ts
@@ -50,7 +50,7 @@ export class Member extends Base<UpgradedTeamMemberPayload> {
         }
 
         if ("isOwner" in data && typeof data.isOwner !== "undefined") {
-            this.isOwner == data.isOwner;
+            this.isOwner = data.isOwner;
         }
 
         return this;

--- a/packages/guilded.js/lib/structures/Message.ts
+++ b/packages/guilded.js/lib/structures/Message.ts
@@ -27,6 +27,8 @@ export class Message extends Base<ChatMessagePayload> {
     readonly replyMessageIds: string[] = [];
     /** If set, this message will only be seen by those mentioned or replied to. */
     readonly isPrivate: boolean;
+    /** If set, this message did not notify, mention or reply recipients. */
+    readonly isSilent: boolean;
     /** The ID of the user who created this message (Note: If this event has createdByBotId or createdByWebhookId present, this field will still be populated, but can be ignored. In these cases, the value of this field will always be Ann6LewA) */
     readonly createdById: string;
     /** The ID of the bot who created this message, if it was created by a bot */
@@ -56,6 +58,7 @@ export class Message extends Base<ChatMessagePayload> {
         this.createdAt = new Date(data.createdAt);
         this.updatedAt = null;
         this.isPrivate = data.isPrivate ?? false;
+        this.isSilent = data.isSilent ?? false;
         this.type = data.type === "system" ? MessageType.System : MessageType.Default;
 
         this._update(data);
@@ -115,9 +118,9 @@ export class Message extends Base<ChatMessagePayload> {
             this.channelId,
             typeof content !== "string"
                 ? {
-                    ...content,
-                    replyMessageIds: content.replyMessageIds ? [this.id, ...content.replyMessageIds] : [this.id],
-                }
+                      ...content,
+                      replyMessageIds: content.replyMessageIds ? [this.id, ...content.replyMessageIds] : [this.id],
+                  }
                 : content,
         );
     }


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
Add `isSilent` to message and `isOwner` to server member.

Status
-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
