### PR TITLE
feat: add Collection.maxSize to allow cache disabling

### DIFF
--- a/packages/guilded.js/lib/index.ts
+++ b/packages/guilded.js/lib/index.ts
@@ -2,6 +2,7 @@ export * from "./structures";
 export * from "./structures/Client";
 export * from "./managers/global";
 export * from "./gateway/ClientGatewayHandler";
+export * from "./utils/Collection";
 export * from "./cache";
 export * from "./constants";
 export * from "./util";

--- a/packages/guilded.js/lib/utils/Collection.ts
+++ b/packages/guilded.js/lib/utils/Collection.ts
@@ -1,0 +1,26 @@
+import BaseCollection from "@discordjs/collection";
+
+export class Collection<K, V> extends BaseCollection<K, V> {
+    /** The maximum number of items allowed in this cache. If you want to disable caching, simply set it to 0. If you want to make it unlimited, set it to undefined. */
+    maxSize?: number;
+
+    constructor(entries?: (readonly (readonly [K, V])[] | null) | Map<K, V>, options?: CollectionOptions<K, V>) {
+        super(entries);
+
+        this.maxSize = options?.maxSize;
+    }
+
+    set(key: K, value: V) {
+        // When this collection is maxSized make sure we can add first
+        if ((this.maxSize || this.maxSize === 0) && this.size >= this.maxSize) {
+            return this;
+        }
+
+        return super.set(key, value);
+    }
+}
+
+export interface CollectionOptions<K, V> {
+    /** The maximum number of items allowed in this cache. If you want to disable caching, simply set it to 0. If you want to make it unlimited, set it to undefined. */
+    maxSize?: number;
+}


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

This PR adds a small bit of customization to the Collection class which will allow us to set a maxSize. This allows supporting cache disabling by simply setting the maxSize to 0, instead of heavy forking and customizing to disabling some parts of cache a bot does not need.

Status

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
