### PR TITLE
fix: ListItemUncompleted emitting to wrong event

### DIFF
--- a/packages/guilded.js/lib/gateway/handler/ListEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/ListEventHandler.ts
@@ -18,7 +18,7 @@ export class ListEventHandler extends GatewayEventHandler {
     ListItemUncompleted(data: WSListItemUncompleted) {
         const existingChannel = this.client.channels.cache.get(data.d.listItem.channelId) as ListChannel | undefined;
         if (existingChannel) existingChannel.items.set(data.d.listItem.id, data.d.listItem);
-        return this.client.emit(constants.clientEvents.LIST_ITEM_COMPLETED, data.d.listItem);
+        return this.client.emit(constants.clientEvents.LIST_ITEM_UNCOMPLETED, data.d.listItem);
     }
     ListItemCreated(data: WSListItemCreated) {
         const existingChannel = this.client.channels.cache.get(data.d.listItem.channelId) as ListChannel | undefined;


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
ListItemUncompleted leads to the client event ListItemCompleted and not ListItemUncompleted, this commit fixes it

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
