### PR TITLE
feat: convert embed objects to payload in message send

### DIFF
--- a/packages/guilded.js/lib/util.ts
+++ b/packages/guilded.js/lib/util.ts
@@ -35,7 +35,12 @@ export const buildMemberKey = (serverId: string, memberId: string): string => {
     return `${serverId}:${memberId}`;
 };
 
-export const resolveContentToData = (content: RESTPostChannelMessagesBody | string | Embed) =>
-    typeof content === "string" ? { content } : content instanceof Embed ? { embeds: [content.toJSON()] } : content;
+export const resolveContentToData = (content: RESTPostChannelMessagesBody | string | Embed): RESTPostChannelMessagesBody => {
+    if (typeof content === "string") return { content };
+    if (content instanceof Embed) return { embeds: [content.toJSON()] };
+
+    content.embeds = content.embeds?.map((x) => (x instanceof Embed ? x.toJSON() : x));
+    return content;
+};
 
 export { resolveColor } from "@guildedjs/webhook-client";


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
This PR allows embeds to be converted to payloads in message send methods

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
