### PR TITLE
fix: correct cache option for removing bans

### DIFF
--- a/.changeset/dull-pumpkins-enjoy.md
+++ b/.changeset/dull-pumpkins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"guilded.js": patch
+---
+
+fix: correct cache option for removing bans

--- a/packages/guilded.js/lib/gateway/handler/TeamMemberEventHandler.ts
+++ b/packages/guilded.js/lib/gateway/handler/TeamMemberEventHandler.ts
@@ -46,7 +46,7 @@ export class TeamMemberEventHandler extends GatewayEventHandler {
     teamMemberUnbanned(data: WSTeamMemberUnbannedPayload): boolean {
         const memberKey = buildMemberKey(data.d.serverId, data.d.serverMemberBan.user.id);
         const existingMemberBan = this.client.bans.cache.get(memberKey);
-        if (existingMemberBan && this.client.options.cache?.removeMemberOnLeave) this.client.bans.cache.delete(existingMemberBan.id);
+        if (existingMemberBan && this.client.options.cache?.removeMemberBanOnUnban) this.client.bans.cache.delete(existingMemberBan.id);
         const existingMember = this.client.members.cache.get(memberKey);
         if (existingMember) existingMember._update({ banned: false });
         return this.client.emit(constants.clientEvents.MEMBER_UNBANNED, existingMemberBan ?? data.d);

--- a/packages/guilded.js/lib/managers/global/GuildBanManager.ts
+++ b/packages/guilded.js/lib/managers/global/GuildBanManager.ts
@@ -48,7 +48,7 @@ export class GlobalGuildBanManager extends CacheableStructManager<string, Member
         return this.client.rest.router.unbanMember(serverId, userId).then((data) => {
             const memberKey = buildMemberKey(serverId, userId);
             const existingBan = this.client.bans.cache.get(memberKey);
-            if (this.client.options.cache?.removeMemberOnLeave || removeBanIfCached) this.client.bans.cache.delete(memberKey);
+            if (this.client.options.cache?.removeMemberBanOnUnban || removeBanIfCached) this.client.bans.cache.delete(memberKey);
             return existingBan ?? null;
         });
     }


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Previously, we were using the `removeMemberOnLeave` cache option to check whether bans should be removed, even though we have a `removeMemberBanOnUnban` prop

Status

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
