### PR TITLE
feat: added verbose logging to errors

### DIFF
--- a/.changeset/sour-ladybugs-count.md
+++ b/.changeset/sour-ladybugs-count.md
@@ -1,0 +1,6 @@
+---
+"@guildedjs/rest": major
+"@guildedjs/proxy-service": minor
+---
+
+feat: verbose logging

--- a/packages/rest/lib/RestManager.ts
+++ b/packages/rest/lib/RestManager.ts
@@ -70,7 +70,7 @@ export class RestManager {
      * Generate obfuscated token. It replaces every char in a non-even index with X. I'm not very creative.
      */
     get obfuscatedToken(): string {
-        return this.token.split("").reduce((prev, curr, index) => index % 2 ? prev + curr : prev + "X", "")
+        return this.token.split("").map(x => "X").join("");
     }
 
     public async make<T extends JSONB, B = RequestBodyObject, Q = never>(

--- a/packages/rest/lib/RestManager.ts
+++ b/packages/rest/lib/RestManager.ts
@@ -93,7 +93,7 @@ export class RestManager {
                 // This gets changed later on if the request is formdata.
                 "content-type": "application/json",
                 // Used for logging on Guilded end.
-                "User-Agent": `@guildedjs-rest/${packageDetails.version} Node.js v${process.version}`,
+                "User-Agent": `@guildedjs-rest/${packageDetails.version} Node.js ${process.version}`,
                 // Spread the other headers like authentication.
                 ...headers,
                 // Spread any additional headers passed from the method.
@@ -166,8 +166,11 @@ export class RestManager {
             };
 
             // obfuscate token in requestOptions for logging purposes.
-            requestOptions.headers.Authorization = this.obfuscatedToken;
+            requestOptions.headers.Authorization = "[OBFUSCATED]";
             
+            // parse stringified JSON bodies back to JSON (added bonus of being able to check here if anything went wrong during the stringifying with any toJSON overrides)
+            if(bodyIsJSON && typeof requestOptions.body === "string") requestOptions.body = JSON.parse(requestOptions.body);
+
             // Occurs when bot has a permission missing
             if (responseDetails.status === 403) {
                 throw new PermissionsError(errorMessage, requestOptions, responseDetails);

--- a/packages/rest/lib/RestManager.ts
+++ b/packages/rest/lib/RestManager.ts
@@ -27,7 +27,7 @@ export type RequestOptions = {
 
 export type ResponseDetails = {
     body: JSONB | string;
-    headers: Headers;
+    headers: Record<string, string>;
     status: number;
 };
 
@@ -151,16 +151,23 @@ export class RestManager {
                 }
             }
 
+            const mapHeadersToObj: Record<string, string> = {};
+            // This is done because Headers isn't stringifiable or iterable without the use of the forEach method.
+            // eslint-disable-next-line unicorn/no-array-for-each
+            response.headers.forEach((v, k) => { 
+                mapHeadersToObj[k] = v 
+            });
+
             // Details response object for error reporting.
             const responseDetails: ResponseDetails = {
                 status: response.status,
-                headers: response.headers,
+                headers: mapHeadersToObj,
                 body: parsedResponse,
             };
 
             // obfuscate token in requestOptions for logging purposes.
             requestOptions.headers.Authorization = this.obfuscatedToken;
-
+            
             // Occurs when bot has a permission missing
             if (responseDetails.status === 403) {
                 throw new PermissionsError(errorMessage, requestOptions, responseDetails);

--- a/packages/rest/lib/errors/GuildedAPIError.ts
+++ b/packages/rest/lib/errors/GuildedAPIError.ts
@@ -3,47 +3,7 @@
 import type { RequestOptions, ResponseDetails } from "../RestManager";
 
 export class GuildedAPIError extends Error {
-    method: string;
-    path: string;
-    request: RequestOptions | undefined;
-    response: ResponseDetails | undefined;
-
-    public constructor(
-        msg: string,
-        methodOrRequest: RequestOptions | string, // backwards compatibility
-        pathOrResponse: ResponseDetails | string, // backwards compatibility
-        public readonly code?: number | string, // this can be removed eventually, as it should be returned on the response
-    ) {
-        // a lot of wonkiness here in the interest of backwards compatibility
-        let method: string;
-        let path: string;
-        let request: RequestOptions | undefined;
-        let response: ResponseDetails | undefined;
-        if (typeof methodOrRequest === "string") {
-            method = methodOrRequest;
-        } else {
-            method = methodOrRequest.method;
-            request = methodOrRequest;
-            path = methodOrRequest.url;
-        }
-
-        if (typeof pathOrResponse === "string") {
-            path = pathOrResponse;
-        } else {
-            path = "/UNDEFINED-PATH"; // this shouldn't happen
-            response = pathOrResponse;
-        }
-
-        super(`[GuildedAPIError:${code}:${method.toUpperCase()}] ${path} - ${msg}`);
-
-        this.method = method;
-        this.path = path;
-        if (request) {
-            this.request = request;
-        }
-
-        if (response) {
-            this.response = response;
-        }
+    public constructor(msg: string, public readonly request: RequestOptions, public readonly response: ResponseDetails) {
+        super(`[GuildedAPIError:${response.status}:${request.method.toUpperCase()}] ${request.url} - ${msg}`);
     }
 }

--- a/packages/rest/lib/errors/GuildedAPIError.ts
+++ b/packages/rest/lib/errors/GuildedAPIError.ts
@@ -1,7 +1,49 @@
 /* istanbul ignore file */
 
+import type { RequestOptions, ResponseDetails } from "../RestManager";
+
 export class GuildedAPIError extends Error {
-    public constructor(msg: string, public readonly method: string, public readonly path: string, public readonly code: number | string) {
+    method: string;
+    path: string;
+    request: RequestOptions | undefined;
+    response: ResponseDetails | undefined;
+
+    public constructor(
+        msg: string,
+        methodOrRequest: RequestOptions | string, // backwards compatibility
+        pathOrResponse: ResponseDetails | string, // backwards compatibility
+        public readonly code?: number | string, // this can be removed eventually, as it should be returned on the response
+    ) {
+        // a lot of wonkiness here in the interest of backwards compatibility
+        let method: string;
+        let path: string;
+        let request: RequestOptions | undefined;
+        let response: ResponseDetails | undefined;
+        if (typeof methodOrRequest === "string") {
+            method = methodOrRequest;
+        } else {
+            method = methodOrRequest.method;
+            request = methodOrRequest;
+            path = methodOrRequest.url;
+        }
+
+        if (typeof pathOrResponse === "string") {
+            path = pathOrResponse;
+        } else {
+            path = "/UNDEFINED-PATH"; // this shouldn't happen
+            response = pathOrResponse;
+        }
+
         super(`[GuildedAPIError:${code}:${method.toUpperCase()}] ${path} - ${msg}`);
+
+        this.method = method;
+        this.path = path;
+        if (request) {
+            this.request = request;
+        }
+
+        if (response) {
+            this.response = response;
+        }
     }
 }

--- a/packages/rest/lib/errors/PermissionsError.ts
+++ b/packages/rest/lib/errors/PermissionsError.ts
@@ -1,7 +1,14 @@
+import path from "node:path";
+import type { RequestOptions, ResponseDetails } from "../RestManager";
 import { GuildedAPIError } from "./GuildedAPIError";
 
 export class PermissionsError extends GuildedAPIError {
-    public constructor(msg: string, method: string, path: string, public readonly missingPermissions: string[]) {
-        super(msg, method, path, 403);
+    public constructor(
+        msg: string,
+        methodOrRequest: RequestOptions | string, // backwards compatibility
+        pathOrResponse: ResponseDetails | string, // backwards compatibility
+        public readonly missingPermissions?: string[], // this can be removed eventually, as it should be returned on the response
+    ) {
+        super(msg, methodOrRequest, pathOrResponse, 403);
     }
 }

--- a/packages/rest/lib/errors/PermissionsError.ts
+++ b/packages/rest/lib/errors/PermissionsError.ts
@@ -1,14 +1,13 @@
-import path from "node:path";
 import type { RequestOptions, ResponseDetails } from "../RestManager";
 import { GuildedAPIError } from "./GuildedAPIError";
 
 export class PermissionsError extends GuildedAPIError {
     public constructor(
         msg: string,
-        methodOrRequest: RequestOptions | string, // backwards compatibility
-        pathOrResponse: ResponseDetails | string, // backwards compatibility
-        public readonly missingPermissions?: string[], // this can be removed eventually, as it should be returned on the response
+        request: RequestOptions,
+        response: ResponseDetails,
+        public readonly missingPermissions?: string[]
     ) {
-        super(msg, methodOrRequest, pathOrResponse, 403);
+        super(msg, request, response);
     }
 }

--- a/packages/rest/lib/errors/PermissionsError.ts
+++ b/packages/rest/lib/errors/PermissionsError.ts
@@ -5,8 +5,7 @@ export class PermissionsError extends GuildedAPIError {
     public constructor(
         msg: string,
         request: RequestOptions,
-        response: ResponseDetails,
-        public readonly missingPermissions?: string[]
+        response: ResponseDetails
     ) {
         super(msg, request, response);
     }

--- a/services/proxy/src/index.ts
+++ b/services/proxy/src/index.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createServer } from "node:http";
+import type { HTTPMethods} from "@guildedjs/rest";
 import { GuildedAPIError, RestManager } from "@guildedjs/rest";
 import { config } from "dotenv";
 
@@ -27,7 +28,7 @@ const server = createServer((req, res) => {
 			const [request, requestBody] = await rest.make(
 				{
 					path: req.url!,
-					method: req.method!,
+					method: req.method! as HTTPMethods,
 					body: body.length ? Buffer.concat(body).toString() : undefined,
 				},
 				true,
@@ -43,7 +44,7 @@ const server = createServer((req, res) => {
 			res.end(resBodyParsed);
 		} catch (error) {
 			if (error instanceof GuildedAPIError) {
-				res.statusCode = Number(error.code);
+				res.statusCode = Number(error.response.status);
 				return res.end(JSON.stringify({ error: { message: error.message } }));
 			}
 


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Status

-   [x] Code changes have been tested.
      - I was unable to run the tests locally. It seems like they're [commented out in CI](https://github.com/rkoval/guilded.js/blob/6fdf212ad957569c1c60918830c1af1eec9806bc/.github/workflows/ci.yml#L40-L41), so I'm unsure how to verify the behavior I created. Please advise!! (edit: I spoke with @zaida04 about this and he's going to look into this)

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.

--- 

## Yo! Ryan from Guilded Staff here! :pizza:

First of all, thank you so much for your continued interest in Guilded and its bot API!!! We love seeing the passion in the community for building fun stuff against the product. This library has opened the door to JavaScript and TypeScript devs to be able to write bots quickly in these languages. Nice work there!!

This PR serves to bring this library to conformance with the "Verbose Logging" guildeline in [Guilded's Bot Library Guidelines document](https://www.guilded.gg/API-Official/groups/53NVy4j3/channels/9fd03b10-c4a1-4c3a-814a-5f6a7b39c632/docs/324317). We have been having trouble working through various support issues recently in our community server for this library, and I think a lot of the pain points come from missing some details from the "Verbose Logging" [1]. From the brief look I took, it _does_ look like this library conforms to the other guidelines in that doc though, so nice work otherwise!! 

Some outstanding issues with this PR that I will hand off to the library maintainers to fix (mostly done in the interest of time, sorry for wall of text!):

- There is a lot of wonkiness in the error constructor because I was trying to appease backwards compatibility of the exported errors. I am not a TypeScript expert, so it's entirely possible this can be done in a better way [2]. I'd encourage you to heavily scrutinize what I wrote to ensure I didn't leave anything through the cracks. I'd also encourage you to create a deprecation path for the previous approach so that this wonkiness can be eventually removed if not done during this code review.
- I did not obfuscate the `authorization` header due because I don't know how this library handles case sensitivity of the header given the underlying object is a POJO, not a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object. **This must be done before merging**, as it's a security risk outputting it as-is. There are loud FIXMEs explaining where
- I did not spend time properly typing everything. I'll leave that up to the library devs though because there may be context I'm missing as to how to properly type things in accordance to patterns that exist in the rest of the library. I'd encourage you to fill the gaps that I left (e.g., not using `any`, etc.)!
- I am not sure how best to document this new behavior, as the constructor may be more of an internally used mechanism and the errors are only exported for `instanceof` checks. It's possible nothing is needed here?
- There may be miscellaneous other things that don't conform to patterns that exist elsewhere in the codebase. Please feel free to blow away and rework anything I did here _as long as the end state is that the requests and responses are being output as I've originally done here_.

**I encourage you to prioritize fixing the outstanding issues, merging the PR, and creating a new release so that the Guilded support team can better help debugging various API issues going forward.** Please let me know how I can help in facilitating a quick turnaround here.

---

- [1] It's entirely possible that the existing verbiage in our "Verbose Logging" guideline is not clear enough for what libraries should look like. Please let us know if that is the case so that we can ensure other bot/library devs can understand this critical point!
- [2] A question I had: can you type entire function arg arrays so that the V1 and V2 ways can be mutually exclusive? This would potentially make it so the compiler enforces that the constructors can _only_ be invoked in 2 specific ways: the v2 way in `(msg: string, methodOrRequest: RequestOptions, pathOrResponse: ResponseDetails)` or v1 way in `(msg: string, methodOrRequest: string, pathOrResponse: string, code: number)`. This is in contrast with what is currently written that technically allows for mixing and matching of parameters such that you could invoke it like `(msg: string, methodOrRequest: string, pathOrResponse: ResponseDetails)`, which is somewhere in between V1 and V2 usage and is bad.
