### PR TITLE
feat: server subscription tier manager and class

### DIFF
--- a/.changeset/silent-otters-sneeze.md
+++ b/.changeset/silent-otters-sneeze.md
@@ -1,0 +1,5 @@
+---
+"guilded.js": minor
+---
+
+Implemented the GlobalSubscriptionManager for ServerSubscriptionTier's and added it to the client.

--- a/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
+++ b/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
@@ -22,9 +22,7 @@ export class GlobalSubscriptionManager extends GlobalManager {
       await this.client.rest.router.serverSubscriptions.serverSubscriptionTierRead(
         { serverId, serverSubscriptionTierType }
       );
-    return new ServerSubscriptionTier(this.client, {
-      ...data.serverSubscriptionTier,
-    });
+    return new ServerSubscriptionTier(this.client, data.serverSubscriptionTier);
   }
 
   /**

--- a/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
+++ b/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
@@ -11,12 +11,12 @@ export class GlobalSubscriptionManager extends GlobalManager {
   /**
    * Fetches a subscription tier from a server.
    * @param serverId The ID of the server to fetch the subscription tier from.
-   * @param serverSubscriptionTierType The subscription tier to fetch.
+   * @param tier The type of subscription tier to fetch.
    * @returns A Promise that resolves with the fetched subscription tier.
    */
   async fetch(
     serverId: string,
-    serverSubscriptionTierType: ServerSubscriptionTierType
+    tier: ServerSubscriptionTierType
   ): Promise<ServerSubscriptionTier> {
     const data =
       await this.client.rest.router.serverSubscriptions.serverSubscriptionTierRead(

--- a/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
+++ b/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
@@ -1,0 +1,50 @@
+import {
+  ServerSubscriptionTier,
+  ServerSubscriptionTierType,
+} from "../../structures/Subscription";
+import { GlobalManager } from "./GlobalManager";
+
+/**
+ * A class representing a global subscription tier manager.
+ */
+export class GlobalSubscriptionManager extends GlobalManager {
+  /**
+   * Fetches a subscription tier from a server.
+   * @param serverId The ID of the server to fetch the subscription tier from.
+   * @param serverSubscriptionTierType The subscription tier to fetch.
+   * @returns A Promise that resolves with the fetched subscription tier.
+   */
+  async fetch(
+    serverId: string,
+    serverSubscriptionTierType: ServerSubscriptionTierType
+  ): Promise<ServerSubscriptionTier> {
+    const data =
+      await this.client.rest.router.serverSubscriptions.serverSubscriptionTierRead(
+        { serverId, serverSubscriptionTierType }
+      );
+    return new ServerSubscriptionTier(this.client, {
+      ...data.serverSubscriptionTier,
+    });
+  }
+
+  /**
+   * Fetches all the subscription tiers from a server.
+   * @param serverId The ID of the server to fetch subscription tiers from.
+   * @returns A Promise that resolves with an array of subscription tiers.
+   */
+  async fetchMany(serverId: string): Promise<ServerSubscriptionTier[]> {
+    const data =
+      await this.client.rest.router.serverSubscriptions.serverSubscriptionTierReadMany(
+        {
+          serverId,
+        }
+      );
+    const serverSubscriptionTiers = [];
+    for (const tier of data.serverSubscriptionTiers) {
+      serverSubscriptionTiers.push(
+        new ServerSubscriptionTier(this.client, tier)
+      );
+    }
+    return serverSubscriptionTiers;
+  }
+}

--- a/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
+++ b/packages/guilded.js/lib/managers/global/SubscriptionManager.ts
@@ -20,7 +20,7 @@ export class GlobalSubscriptionManager extends GlobalManager {
   ): Promise<ServerSubscriptionTier> {
     const data =
       await this.client.rest.router.serverSubscriptions.serverSubscriptionTierRead(
-        { serverId, serverSubscriptionTierType }
+        { serverId, serverSubscriptionTierType: tier }
       );
     return new ServerSubscriptionTier(this.client, data.serverSubscriptionTier);
   }

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -23,6 +23,7 @@ import type { ClientEvents } from "../typings";
 import type { SkeletonWSPayload } from "@guildedjs/api";
 import type { Server } from "./Server";
 import type { Collection } from "@discordjs/collection";
+import { GlobalSubscriptionManager } from "../managers/global/SubscriptionManager";
 
 /**
  * The main class for interacting with the api.
@@ -121,6 +122,11 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
    * A manager for calendars, used to manage and interact with calendars.
    */
   calendars = new GlobalCalendarManager(this);
+
+  /**
+   * A manager for server subscriptions, used to manage and interact with server subscriptions.
+   */
+  subscriptions = new GlobalSubscriptionManager(this);
 
   /**
    * The user belonging to this bot.

--- a/packages/guilded.js/lib/structures/Subscription.ts
+++ b/packages/guilded.js/lib/structures/Subscription.ts
@@ -24,10 +24,10 @@ export class ServerSubscriptionTier extends Base<
   type: ServerSubscriptionTierType;
 
   /** The description associated with the server subscription tier (max length 256) */
-  description?: string;
+  description: string | null;
 
   /** The ID of the role */
-  roleId?: number;
+  roleId: number | null;
 
   /** The cost of the tier in cents USD per month (min 200; max 10000) */
   cost: number;
@@ -40,8 +40,8 @@ export class ServerSubscriptionTier extends Base<
     super(client, { id: data.type, ...data });
     this.serverId = data.serverId;
     this._createdAt = Date.parse(data.createdAt);
-    this.description = data.description;
-    this.roleId = data.roleId;
+    this.description = data.description ?? null;
+    this.roleId = data.roleId ?? null;
     this.cost = data.cost;
     this.type = data.type;
   }

--- a/packages/guilded.js/lib/structures/Subscription.ts
+++ b/packages/guilded.js/lib/structures/Subscription.ts
@@ -1,0 +1,52 @@
+import type { ServerSubscriptionTierPayload } from "@guildedjs/api";
+import { Base } from "./Base";
+import { Client } from "./Client";
+
+/**
+ * Describes a subscription tier type.
+ */
+export type ServerSubscriptionTierType = "Gold" | "Silver" | "Copper";
+
+/**
+ * Represents a Guilded SubscriptionTier in a server.
+ */
+export class ServerSubscriptionTier extends Base<
+  ServerSubscriptionTierPayload,
+  ServerSubscriptionTierType
+> {
+  /** The ID of the server */
+  readonly serverId: string;
+
+  /** The ISO 8601 timestamp that the server subscription tier was created at */
+  _createdAt: number;
+
+  /** The type of the server subscription tier. This field is case sensitive!! */
+  type: ServerSubscriptionTierType;
+
+  /** The description associated with the server subscription tier (max length 256) */
+  description?: string;
+
+  /** The ID of the role */
+  roleId?: number;
+
+  /** The cost of the tier in cents USD per month (min 200; max 10000) */
+  cost: number;
+
+  /**
+   * @param client The client instance
+   * @param data The data for this role
+   */
+  constructor(client: Client, data: ServerSubscriptionTierPayload) {
+    super(client, { id: data.type, ...data });
+    this.serverId = data.serverId;
+    this._createdAt = Date.parse(data.createdAt);
+    this.description = data.description;
+    this.roleId = data.roleId;
+    this.cost = data.cost;
+    this.type = data.type;
+  }
+
+  get createdAt(): Date {
+    return new Date(this._createdAt);
+  }
+}


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
Created new class for users to consume the ServerSubscriptionTier and added a GlobalManager for the ServerSubscriptionTier that implements the basic read/readMany methods.

Status

-   [ ] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
