### PR TITLE
Issue with member.fetch in which it fetches user even if it is a webhook

### DIFF
--- a/.changeset/early-hats-complain.md
+++ b/.changeset/early-hats-complain.md
@@ -1,0 +1,5 @@
+---
+"guilded.js": patch
+---
+
+Issue with member.fetch in which it fetches user even if it is a webhook

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -28,7 +28,7 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
         if (userId === "Ann6LewA") throw new Error("You cannot fetch a webhook as a member. The provided ID (Ann6LewA) is only given to webhooks.");
-        
+
         const memberKey = buildMemberKey(serverId, userId);
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -28,6 +28,9 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
         const memberKey = buildMemberKey(serverId, userId);
+        if (userId === "Ann6LewA") {
+            throw Error("The member fetch call was run on a webhook authorId", "/packagmanagers/global/MemberManager.js", 32)
+        }
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);
             if (existingMember) return existingMember;

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -28,9 +28,7 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
         const memberKey = buildMemberKey(serverId, userId);
-        if (userId === "Ann6LewA") {
-            throw Error("The member fetch call was run on a webhook authorId", "/packagmanagers/global/MemberManager.js", 32)
-        }
+        if (userId === "Ann6LewA") {throw Error("The member fetch call was run on a webhook authorId");}
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);
             if (existingMember) return existingMember;

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -27,8 +27,8 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      * @returns A Promise that resolves with the fetched member.
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
+        if (userId === "Ann6LewA") throw Error("You cannot fetch a webhook as a member. The provided ID (Ann6LewA) is only given to webhooks.");
         const memberKey = buildMemberKey(serverId, userId);
-        if (userId === "Ann6LewA") throw Error("The member fetch call was run on a webhook authorId");
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);
             if (existingMember) return existingMember;

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -28,7 +28,7 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
         const memberKey = buildMemberKey(serverId, userId);
-        if (userId === "Ann6LewA") {throw Error("The member fetch call was run on a webhook authorId");}
+        if (userId === "Ann6LewA") throw Error("The member fetch call was run on a webhook authorId");
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);
             if (existingMember) return existingMember;

--- a/packages/guilded.js/lib/managers/global/MemberManager.ts
+++ b/packages/guilded.js/lib/managers/global/MemberManager.ts
@@ -27,7 +27,8 @@ export class GlobalMemberManager extends CacheableStructManager<string, Member> 
      * @returns A Promise that resolves with the fetched member.
      */
     async fetch(serverId: string, userId: string, force?: boolean): Promise<Member> {
-        if (userId === "Ann6LewA") throw Error("You cannot fetch a webhook as a member. The provided ID (Ann6LewA) is only given to webhooks.");
+        if (userId === "Ann6LewA") throw new Error("You cannot fetch a webhook as a member. The provided ID (Ann6LewA) is only given to webhooks.");
+        
         const memberKey = buildMemberKey(serverId, userId);
         if (!force) {
             const existingMember = this.client.members.cache.get(memberKey);


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:
This fixes an issue where the meber.fetch will try and fetch the webhook "authorid"

Status

-   [X] Code changes have been tested.

Semantic versioning classification:

-   [ ] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
