### PR TITLE
feat: header options for WS and REST

### DIFF
--- a/.changeset/cool-wolves-sniff.md
+++ b/.changeset/cool-wolves-sniff.md
@@ -1,0 +1,6 @@
+---
+"@guildedjs/api": patch
+"guilded.js": patch
+---
+
+feat: header options for WS and REST

--- a/packages/api/lib/rest/RestManager.ts
+++ b/packages/api/lib/rest/RestManager.ts
@@ -117,6 +117,9 @@ export class RestManager {
 				"User-Agent": `@guildedjs-rest/${packageDetails.version} Node.js ${process.version}`,
 				// Spread the other headers like authentication.
 				...headers,
+				// User supplided. This will be after Guilded.js default headers to allow modifying, but before request's specific one
+				// to still allow per-request modifications
+				...this.options.headers,
 				// Spread any additional headers passed from the method.
 				...data.headers,
 			},

--- a/packages/api/lib/rest/typings.ts
+++ b/packages/api/lib/rest/typings.ts
@@ -19,4 +19,8 @@ export type RestOptions = {
 	 * The version of the API to be used for making requests. By default, this will use the latest version that the library supports.
 	 */
 	version?: 1;
+	/**
+	 * The additional headers that will be added to each request done by RestManager.
+	 */
+	headers?: Record<string, string>;
 };

--- a/packages/api/lib/ws/WebSocketManager.ts
+++ b/packages/api/lib/ws/WebSocketManager.ts
@@ -85,8 +85,10 @@ export class WebSocketManager {
 
 	connect(): void {
 		this._debug(`Connecting to Guilded WS Gateway at url ${this.wsURL}.`);
+		// Since rest supplies custom headers after authorization header, WS will be the same in that regard
 		const headers: Record<string, string> = {
 			Authorization: `Bearer ${this.token}`,
+			...this.options.headers,
 		};
 
 		if (this.shouldRequestMissedEvents) {
@@ -287,6 +289,10 @@ export type WebSocketOptions = {
 	 * The version of the websocket to connect to.
 	 */
 	version?: 1;
+	/**
+	 * The additional headers that will be added to WebSocket request upon initial connection.
+	 */
+	headers?: Record<string, string>;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/packages/guilded.js/lib/structures/Client.ts
+++ b/packages/guilded.js/lib/structures/Client.ts
@@ -48,6 +48,7 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
 	 * The websocket connection.
 	 */
 	ws = new WebSocketManager({
+		...this.options.ws,
 		token: this.options.token,
 	});
 
@@ -292,6 +293,25 @@ export type ClientOptions = {
 		 * @remarks If you want to use a custom API url, you can set this property to your custom url.
 		 */
 		proxyURL?: string;
+
+		/**
+		 * The headers that will be supplied in each request that the client, or more precisely, RestManager, will send.
+		 *
+		 * @remarks It's generally only recommended to supply headers that may be required for Guilded experiments, as vital headers will be supplied by Guilded.js.
+		 */
+		headers?: Record<string, string>;
+	};
+
+	/**
+	 * Options that will be given directly to WebSocket.
+	 */
+	ws?: {
+		/**
+		 * The headers that will be supplied when WebSocket is being initialized and its request is made.
+		 *
+		 * @remarks It's generally only recommended to supply headers that may be required for Guilded experiments, as vital headers will be supplied by Guilded.js.
+		 */
+		headers?: Record<string, string>;
 	};
 
 	/**


### PR DESCRIPTION
Adds `headers` to options to both WS and REST to allow easier access to Guilded API experiments today and in the future. This also adds client option `ws` that will be handed to the WebSocket directly (which is what is done to REST as of now).

Status

-   [x] Code changes have been tested.

Semantic versioning classification:

-   [x] This PR changes the library's interface (methods or parameters added)
-   [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-   [ ] This PR only includes non-code changes, like changes to documentation, README, etc.
